### PR TITLE
Fix bug with rendering slide type after saving it as one specific type

### DIFF
--- a/app/controllers/admin/slides_controller.rb
+++ b/app/controllers/admin/slides_controller.rb
@@ -88,7 +88,9 @@ class Admin::SlidesController < ApplicationController
     if slide.update_preview?
       slide.confirm_save
     else
-      slide.update(slide_params)
+      params = slide_params
+      params.merge!(role: "confirm#{slide.determine_role}")
+      slide.update(params)
     end
   end
 end

--- a/app/models/slide.rb
+++ b/app/models/slide.rb
@@ -133,6 +133,7 @@ class Slide < ActiveRecord::Base
       slides[:orig].update(
         ribbon: slides[:changes].ribbon,
         ribbon_color: slides[:changes].ribbon_color,
+        role: "confirm#{determine_role(slides[:changes])}",
         title: slides[:changes].title,
         subtitle: slides[:changes].subtitle,
         ribbon_display: slides[:changes].ribbon_display,


### PR DESCRIPTION
The slide will continue to update its type as you change and edit it.